### PR TITLE
Optional login

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -95,7 +95,7 @@ func (r *oauthProxy) authenticateRequest(w http.ResponseWriter, req *http.Reques
 	user, err := r.getIdentity(req)
 	if err != nil {
 		r.log.Error("no session found in request, redirecting for authorization", zap.Error(err))
-		return responseTypeRedirectAuthentication, nil
+		return responseTypeRedirectAuthentication, req.Context()
 	}
 	// create the request scope
 	scope := req.Context().Value(contextScopeName).(*RequestScope)
@@ -214,7 +214,9 @@ func (r *oauthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 			if resource.WhiteListed {
 				switch responseType {
 				case responseTypeServe:
+					fallthrough
 				case responseTypeRedirectAuthentication:
+					fallthrough
 				case responseTypeAccessForbidden:
 					next.ServeHTTP(w, req.WithContext(ctx))
 					return

--- a/middleware.go
+++ b/middleware.go
@@ -83,10 +83,10 @@ func (r *oauthProxy) loggingMiddleware(next http.Handler) http.Handler {
 }
 
 const (
-	responseTypeServe = 0
+	responseTypeServe                  = 0
 	responseTypeRedirectAuthentication = 1
-	responseTypeAccessForbidden = 2
-	responseTypeError = 3
+	responseTypeAccessForbidden        = 2
+	responseTypeError                  = 3
 )
 
 func (r *oauthProxy) authenticateRequest(w http.ResponseWriter, req *http.Request) (int, context.Context) {

--- a/server.go
+++ b/server.go
@@ -244,13 +244,16 @@ func (r *oauthProxy) createReverseProxy() error {
 			r.authenticationMiddleware(x),
 			r.admissionMiddleware(x),
 			r.headersMiddleware(r.config.AddClaims))
+		eWhiteListed := engine.With(
+			r.authenticationMiddleware(x),
+			r.headersMiddleware(r.config.AddClaims))
 
 		for _, m := range x.Methods {
-			if !x.WhiteListed {
+			if x.WhiteListed {
+				eWhiteListed.MethodFunc(m, x.URL, emptyHandler)
+			} else {
 				e.MethodFunc(m, x.URL, emptyHandler)
-				continue
 			}
-			engine.MethodFunc(m, x.URL, emptyHandler)
 		}
 	}
 


### PR DESCRIPTION
This patch from @justjanne addresses the issue of sites with pages that need to behave differently depending on whether a user is actually logged in.  Specifically, it:

Transmit auth headers even for whitelisted resources

- Let whitelisted resources also be handled by authentication and
  headers middleware, but not by admission middleware

- Refactor authentication middleware into a function that returns the
  type of response that is expected (authenticateRequest), and one
  that acts on it (authenticationMiddleware)

- Handle the responseTypes RedirectAuthentication and AccessForbidden
  the same as Serve if the resource is whitelisted