### PR TITLE
[KEYCLOAK-9103] Improve TLS settings for proxy listener

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/url"
@@ -215,4 +216,158 @@ func (r *Config) hasCustomSignInPage() bool {
 // hasForbiddenPage checks if there is a custom forbidden page
 func (r *Config) hasCustomForbiddenPage() bool {
 	return r.ForbiddenPage != ""
+}
+
+// tlsAdvancedConfig holds advanced parameters to control TLS negotiation
+type tlsAdvancedConfig struct {
+	tlsUseModernSettings        bool
+	tlsPreferServerCipherSuites bool
+	tlsMinVersion               string
+	tlsCipherSuites             []string
+	tlsCurvePreferences         []string
+}
+
+// tlsSettings holds advanced TLS parameters, parsed from config
+type tlsSettings struct {
+	tlsPreferServerCipherSuites bool
+	tlsMinVersion               uint16
+	tlsCipherSuites             []uint16
+	tlsCurvePreferences         []tls.CurveID
+}
+
+func parseTLS(config *tlsAdvancedConfig) (*tlsSettings, error) {
+	parsed := &tlsSettings{}
+
+	parsed.tlsPreferServerCipherSuites = config.tlsPreferServerCipherSuites || config.tlsUseModernSettings
+
+	if config.tlsMinVersion != "" {
+		switch config.tlsMinVersion {
+		case "SSL3.0":
+			parsed.tlsMinVersion = tls.VersionSSL30
+		case "TLS1.0":
+			parsed.tlsMinVersion = tls.VersionTLS10
+		case "TLS1.1":
+			parsed.tlsMinVersion = tls.VersionTLS11
+		case "TLS1.2":
+			parsed.tlsMinVersion = tls.VersionTLS12
+		default:
+			return nil, errors.New("invalid TLS version configured. Accepted values are: SSL3.0, TLS1.0, TLS1.1, TLS1.2")
+		}
+	} else if config.tlsUseModernSettings {
+		// standard modern setting
+		// https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet#Rule_-_Only_Support_Strong_Protocols
+		parsed.tlsMinVersion = tls.VersionTLS12
+	}
+
+	if config.tlsUseModernSettings || len(config.tlsCurvePreferences) > 0 {
+		if len(config.tlsCurvePreferences) > 0 {
+			parsed.tlsCurvePreferences = make([]tls.CurveID, 0, len(config.tlsCurvePreferences))
+			for _, curveName := range config.tlsCurvePreferences {
+				switch curveName {
+				case "P256":
+					parsed.tlsCurvePreferences = append(parsed.tlsCurvePreferences, tls.CurveP256)
+				case "P384":
+					parsed.tlsCurvePreferences = append(parsed.tlsCurvePreferences, tls.CurveP384)
+				case "P521":
+					parsed.tlsCurvePreferences = append(parsed.tlsCurvePreferences, tls.CurveP521)
+				case "X25519":
+					parsed.tlsCurvePreferences = append(parsed.tlsCurvePreferences, tls.X25519)
+				default:
+					return nil, errors.New("invalid TLS curve configured. Accepted values are: P256, P384, P521, X25519")
+				}
+			}
+		} else if config.tlsUseModernSettings {
+			// standard modern settings
+			// Only use curves which have assembly implementations
+			// https://github.com/golang/go/tree/master/src/crypto/elliptic
+			parsed.tlsCurvePreferences = []tls.CurveID{
+				tls.CurveP256,
+				tls.X25519,
+			}
+		}
+	}
+
+	if config.tlsUseModernSettings || len(config.tlsCipherSuites) > 0 {
+		parsed.tlsCipherSuites = make([]uint16, 0, len(config.tlsCurvePreferences))
+		for _, cipher := range config.tlsCipherSuites {
+			switch cipher {
+			case "TLS_FALLBACK_SCSV":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_FALLBACK_SCSV)
+			case "TLS_RSA_WITH_RC4_128_SHA":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_RSA_WITH_RC4_128_SHA)
+			case "TLS_RSA_WITH_3DES_EDE_CBC_SHA":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA)
+			case "TLS_RSA_WITH_AES_128_CBC_SHA":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_RSA_WITH_AES_128_CBC_SHA)
+			case "TLS_RSA_WITH_AES_256_CBC_SHA":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_RSA_WITH_AES_256_CBC_SHA)
+			case "TLS_RSA_WITH_AES_128_CBC_SHA256":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_RSA_WITH_AES_128_CBC_SHA256)
+			case "TLS_RSA_WITH_AES_128_GCM_SHA256":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_RSA_WITH_AES_128_GCM_SHA256)
+			case "TLS_RSA_WITH_AES_256_GCM_SHA384":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_RSA_WITH_AES_256_GCM_SHA384)
+			case "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA)
+			case "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA)
+			case "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA)
+			case "TLS_ECDHE_RSA_WITH_RC4_128_SHA":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA)
+			case "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA)
+			case "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)
+			case "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA)
+			case "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256)
+			case "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256)
+			case "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
+			case "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
+			case "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384)
+			case "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384)
+			case "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305)
+			case "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":
+				parsed.tlsCipherSuites = append(parsed.tlsCipherSuites, tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305)
+			default:
+				return nil, errors.New("invalid TLS cipher suite configured. Accepted values are listed at https://golang.org/pkg/crypto/tls/#pkg-constants")
+			}
+		}
+		if config.tlsUseModernSettings && len(config.tlsCurvePreferences) == 0 {
+			// Use modern tls mode https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+			// See security linter code: https://github.com/securego/gosec/blob/master/rules/tls_config.go#L11
+			// These ciphersuites support Forward Secrecy: https://en.wikipedia.org/wiki/Forward_secrecy
+			parsed.tlsCipherSuites = []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			}
+		}
+		// when some cipher preferences are explicitly provided, enforce the presence of TLS_FALLBACK_SCSV
+		// at the top of cipher suites preferences.
+		// When no suites are specified, stick to golang's defaults.
+		if len(parsed.tlsCipherSuites) > 0 {
+			enforcedSCSV := make([]uint16, 1, len(parsed.tlsCipherSuites)+1)
+			enforcedSCSV[0] = tls.TLS_FALLBACK_SCSV
+			for _, cph := range parsed.tlsCipherSuites {
+				if cph == tls.TLS_FALLBACK_SCSV {
+					continue
+				}
+				enforcedSCSV = append(enforcedSCSV, cph)
+			}
+			parsed.tlsCipherSuites = enforcedSCSV
+		}
+	}
+	return parsed, nil
 }

--- a/doc.go
+++ b/doc.go
@@ -265,17 +265,27 @@ type Config struct {
 	AddClaims []string `json:"add-claims" yaml:"add-claims" usage:"extra claims from the token and inject into headers, e.g given_name -> X-Auth-Given-Name"`
 
 	// TLSCertificate is the location for a tls certificate
-	TLSCertificate string `json:"tls-cert" yaml:"tls-cert" usage:"path to ths TLS certificate"`
+	TLSCertificate string `json:"tls-cert" yaml:"tls-cert" usage:"path to ths TLS certificate" env:"TLS_CERTIFICATE"`
 	// TLSPrivateKey is the location of a tls private key
-	TLSPrivateKey string `json:"tls-private-key" yaml:"tls-private-key" usage:"path to the private key for TLS"`
+	TLSPrivateKey string `json:"tls-private-key" yaml:"tls-private-key" usage:"path to the private key for TLS" env:"TLS_PRIVATE_KEY"`
 	// TLSCaCertificate is the CA certificate which the client cert must be signed
-	TLSCaCertificate string `json:"tls-ca-certificate" yaml:"tls-ca-certificate" usage:"path to the ca certificate used for signing requests"`
+	TLSCaCertificate string `json:"tls-ca-certificate" yaml:"tls-ca-certificate" usage:"path to the ca certificate used for signing requests" env:"TLS_CA_CERTIFICATE"`
 	// TLSCaPrivateKey is the CA private key used for signing
-	TLSCaPrivateKey string `json:"tls-ca-key" yaml:"tls-ca-key" usage:"path the ca private key, used by the forward signing proxy"`
+	TLSCaPrivateKey string `json:"tls-ca-key" yaml:"tls-ca-key" usage:"path the ca private key, used by the forward signing proxy" env:"TLS_CA_PRIVATE_KEY"`
 	// TLSClientCertificate is path to a client certificate to use for outbound connections
-	TLSClientCertificate string `json:"tls-client-certificate" yaml:"tls-client-certificate" usage:"path to the client certificate for outbound connections in reverse and forwarding proxy modes"`
+	TLSClientCertificate string `json:"tls-client-certificate" yaml:"tls-client-certificate" usage:"path to the client certificate for outbound connections in reverse and forwarding proxy modes" env:"TLS_CLIENT_CERTIFICATE"`
+	// TLSUseModernSettings sets all TLS options for proxy listener to modern settings (TLS 1.2, advanced cipher suites, ...)
+	TLSUseModernSettings bool `json:"tls-use-modern-settings" yaml:"tls-use-modern-settings" usage:"sets all TLS options for proxy listener to modern settings (TLS 1.2, advanced cipher suites, ...)" env:"TLS_USE_MODERN_SETTINGS"`
+	// TLSMinVersion is the minimum TLS protocol version accepted by proxy listener. TLS 1.0 is the default.
+	TLSMinVersion string `json:"tls-min-version" yaml:"tls-min-version" usage:"the minimum TLS protocol version accepted by proxy listener. Accepted values are: SSL3.0, TLS1.0, TLS1.1, TLS1.2. TLS1.0 is the default" env:"TLS_MIN_VERSION"`
+	// TLSCipherSuites is the list of cipher suites accepted by server during TLS negotiation. Defaults to golang TLS supported suites.
+	TLSCipherSuites []string `json:"tls-cipher-suites" yaml:"tls-cipher-suites" usage:"the list of cipher suites accepted by server during TLS negotiation. Defaults to golang TLS supported suites" env:"TLS_CIPHER_SUITES"`
+	// TLSPreferServerCipherSuites indicates the TLS negotiation prefers server cipher suites
+	TLSPreferServerCipherSuites bool `json:"tls-prefer-server-cipher-suites" yaml:"tls-prefer-server-cipher-suites" usage:"indicates the TLS negotiation prefers server cipher suites" env:"TLS_PREFER_SERVER_CIPHER_SUITES"`
+	// TLSCurvePreferences indicate the server preferred cipher curves
+	TLSCurvePreferences []string `json:"tls-curve-preferences" yaml:"tls-curve-preferences" usage:"the server preferred cipher curves" env:"TLS_CURVE_PREFERENCES"`
 	// SkipUpstreamTLSVerify skips the verification of any upstream tls
-	SkipUpstreamTLSVerify bool `json:"skip-upstream-tls-verify" yaml:"skip-upstream-tls-verify" usage:"skip the verification of any upstream TLS"`
+	SkipUpstreamTLSVerify bool `json:"skip-upstream-tls-verify" yaml:"skip-upstream-tls-verify" usage:"skip the verification of any upstream TLS" env:"SKIP_UPSTREAM_TLS_VERIFY"`
 
 	// CorsOrigins is a list of origins permitted
 	CorsOrigins []string `json:"cors-origins" yaml:"cors-origins" usage:"origins to add to the CORE origins control (Access-Control-Allow-Origin)"`

--- a/server.go
+++ b/server.go
@@ -312,7 +312,7 @@ func (r *oauthProxy) createForwardingProxy() error {
 			func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
 				return &goproxy.ConnectAction{
 					Action:    goproxy.ConnectMitm,
-					TLSConfig: goproxy.TLSConfigFromCA(ca),
+					TLSConfig: goproxy.TLSConfigFromCA(ca), // NOTE(fredbi): the default proxy config in github/elazarl/goproxy disables TLS verify
 				}, host
 			},
 		)
@@ -363,6 +363,13 @@ func (r *oauthProxy) Run() error {
 		useFileTLS:          r.config.TLSPrivateKey != "" && r.config.TLSCertificate != "",
 		useLetsEncryptTLS:   r.config.UseLetsEncrypt,
 		useSelfSignedTLS:    r.config.EnabledSelfSignedTLS,
+		tlsAdvancedConfig: &tlsAdvancedConfig{
+			tlsMinVersion:               r.config.TLSMinVersion,
+			tlsCurvePreferences:         r.config.TLSCurvePreferences,
+			tlsCipherSuites:             r.config.TLSCipherSuites,
+			tlsUseModernSettings:        r.config.TLSUseModernSettings,
+			tlsPreferServerCipherSuites: r.config.TLSPreferServerCipherSuites,
+		},
 	})
 
 	if err != nil {
@@ -429,6 +436,9 @@ type listenerConfig struct {
 	useFileTLS          bool     // indicates we are using certificates from files
 	useLetsEncryptTLS   bool     // indicates we are using letsencrypt
 	useSelfSignedTLS    bool     // indicates we are using the self-signed tls
+
+	// advanced TLS settings
+	*tlsAdvancedConfig
 }
 
 // ErrHostNotConfigured indicates the hostname was not configured
@@ -526,15 +536,24 @@ func (r *oauthProxy) createHTTPListener(config listenerConfig) (net.Listener, er
 			getCertificate = rotate.GetCertificate
 		}
 
-		tlsConfig := &tls.Config{
-			GetCertificate:           getCertificate,
-			PreferServerCipherSuites: true,
-			NextProtos:               []string{"h2", "http/1.1"},
+		ts, err := parseTLS(config.tlsAdvancedConfig)
+		if err != nil {
+			return nil, err
 		}
 
-		listener = tls.NewListener(listener, tlsConfig)
+		//#nosec G402
+		tlsConfig := &tls.Config{
+			GetCertificate: getCertificate,
+			// Causes servers to use Go's default ciphersuite preferences,
+			// which are tuned to avoid attacks. Does nothing on clients.
+			PreferServerCipherSuites: ts.tlsPreferServerCipherSuites,
+			CurvePreferences:         ts.tlsCurvePreferences,
+			NextProtos:               []string{"h2", "http/1.1"},
+			MinVersion:               ts.tlsMinVersion,
+			CipherSuites:             ts.tlsCipherSuites,
+		}
 
-		// @check if we doing mutual tls
+		// @check if we are doing mutual tls
 		if config.clientCert != "" {
 			caCert, err := ioutil.ReadFile(config.clientCert)
 			if err != nil {
@@ -545,12 +564,14 @@ func (r *oauthProxy) createHTTPListener(config listenerConfig) (net.Listener, er
 			tlsConfig.ClientCAs = caCertPool
 			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 		}
+
+		listener = tls.NewListener(listener, tlsConfig)
 	}
 
 	return listener, nil
 }
 
-// createUpstreamProxy create a reverse http proxy from the upstream
+// createUpstreamProxy creates a reverse http proxy client to the upstream
 func (r *oauthProxy) createUpstreamProxy(upstream *url.URL) error {
 	dialer := (&net.Dialer{
 		KeepAlive: r.config.UpstreamKeepaliveTimeout,
@@ -569,13 +590,13 @@ func (r *oauthProxy) createUpstreamProxy(upstream *url.URL) error {
 		upstream.Host = "domain-sock"
 		upstream.Scheme = unsecureScheme
 	}
-	// create the upstream tls configure
+	// create the upstream tls configuration
 	//nolint:gas
 	tlsConfig := &tls.Config{InsecureSkipVerify: r.config.SkipUpstreamTLSVerify}
 
-	// are we using a client certificate
-	// @TODO provide a means of reload on the client certificate when it expires. I'm not sure if it's just a
-	// case of update the http transport settings - Also we to place this go-routine?
+	// are we using a client certificate?
+	// @TODO provide a means to reload the client certificate when it expires. I'm not sure if it's just a
+	// case of update the http transport settings - Also where to place this go-routine?
 	if r.config.TLSClientCertificate != "" {
 		cert, err := ioutil.ReadFile(r.config.TLSClientCertificate)
 		if err != nil {
@@ -588,18 +609,16 @@ func (r *oauthProxy) createUpstreamProxy(upstream *url.URL) error {
 		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	}
 
-	{
-		// @check if we have a upstream ca to verify the upstream
-		if r.config.UpstreamCA != "" {
-			r.log.Info("loading the upstream ca", zap.String("path", r.config.UpstreamCA))
-			ca, err := ioutil.ReadFile(r.config.UpstreamCA)
-			if err != nil {
-				return err
-			}
-			pool := x509.NewCertPool()
-			pool.AppendCertsFromPEM(ca)
-			tlsConfig.RootCAs = pool
+	// @check if we have a upstream ca to verify the upstream
+	if r.config.UpstreamCA != "" {
+		r.log.Info("loading the upstream ca", zap.String("path", r.config.UpstreamCA))
+		ca, err := ioutil.ReadFile(r.config.UpstreamCA)
+		if err != nil {
+			return err
 		}
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(ca)
+		tlsConfig.RootCAs = pool
 	}
 
 	// create the forwarding proxy
@@ -650,7 +669,7 @@ func (r *oauthProxy) newOpenIDClient() (*oidc.Client, oidc.ProviderConfig, *http
 	var err error
 	var config oidc.ProviderConfig
 
-	// step: fix up the url if required, the underlining lib will add the .well-known/openid-configuration to the discovery url for us.
+	// step: fix up the url if required, the underlying lib will add the .well-known/openid-configuration to the discovery url for us.
 	if strings.HasSuffix(r.config.DiscoveryURL, "/.well-known/openid-configuration") {
 		r.config.DiscoveryURL = strings.TrimSuffix(r.config.DiscoveryURL, "/.well-known/openid-configuration")
 	}


### PR DESCRIPTION
* Restricts TLS settings negotiated with clients to modern, secure ciphers and protocols
* Support TLS_FALLBACK_SCSV at the top of ciphers

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>