### PR TITLE
[KEYCLOAK-10242] Fix setting X-Forwarded-For & X-Real-IP

### DIFF
--- a/forwarding.go
+++ b/forwarding.go
@@ -40,7 +40,12 @@ func (r *oauthProxy) proxyMiddleware(next http.Handler) http.Handler {
 		}
 
 		// @step: add the proxy forwarding headers
-		req.Header.Add("X-Forwarded-For", realIP(req))
+		req.Header.Set("X-Real-IP", realIP(req))
+		if xff := req.Header.Get(headerXForwardedFor); xff == "" {
+			req.Header.Set("X-Forwarded-For", realIP(req))
+		} else {
+			req.Header.Set("X-Forwarded-For", xff)
+		}
 		req.Header.Set("X-Forwarded-Host", req.Host)
 		req.Header.Set("X-Forwarded-Proto", req.Header.Get("X-Forwarded-Proto"))
 


### PR DESCRIPTION
fixed setting x-forwarded-for headers, add x-real-ip with discovered client’s address.

Fixes KEYCLOAK-10242

Signed-off-by: Andrey Izotikov <andrsp@gmail.com>