### PR TITLE
KEYCLOAK-10864 Pass URI path upstream verbatim

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -385,6 +385,11 @@ type RequestScope struct {
 	AccessDenied bool
 	// Identity is the user Identity of the request
 	Identity *userContext
+	// The parsed (unescaped) value of the request path
+	Path string
+	// Preserve the original request path: KEYCLOAK-10864, KEYCLOAK-11276, KEYCLOAK-13315
+	// The exact path received in the request, if different than Path
+	RawPath string
 }
 
 // storage is used to hold the offline refresh token, assuming you don't want to use

--- a/server.go
+++ b/server.go
@@ -32,6 +32,8 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap/zapcore"
+
 	"golang.org/x/crypto/acme/autocert"
 
 	httplog "log"
@@ -137,6 +139,8 @@ func createLogger(config *Config) (*zap.Logger, error) {
 	c := zap.NewProductionConfig()
 	c.DisableStacktrace = true
 	c.DisableCaller = true
+	// Use human-readable timestamps in the logs until KEYCLOAK-12100 is fixed
+	c.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	// are we enabling json logging?
 	if !config.EnableJSONLogging {
 		c.Encoding = "console"


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

- Fixes [KEYCLOAK-10864](https://issues.redhat.com/browse/KEYCLOAK-10864) which will also fix [KEYCLOAK-11276](https://issues.redhat.com/browse/KEYCLOAK-11276) and [KEYCLOAK-13315](https://issues.redhat.com/browse/KEYCLOAK-13315)
- Closes #528
- Closes #483 by superseding it as a bug fix, not an option

No documentation needed, as this is a bug fix. 

### Testing
Very importantly, it passes all the existing unit tests, plus new ones I wrote with URLs associated with open bugs. I also corrected the test rig to properly test the URLs that are being passed upstream rather than the URLs sent to Gatekeeper for proper values.

Of course, the question is, does it also fix the Jenkins problem, and that it does. 

If you use the test setup at https://github.com/primeroz/keycloak-10864-test-jenkins (not written by me) you will see the error message:

![It appears your reverse proxy setup is broken](https://14121030156225464128.googlegroups.com/attach/88589bf274452/Auto%20Generated%20Inline%20Image%201?part=0.1&view=1&vt=ANaJVrEq47PDK3Yzl8QW2yKPFAQQqnyfFi1--SA4A0wYAyI3uWcZ7bfC1F82NIHE8LHG5Hd3Xjhjxie7EKTg_igW0Ckt5wlLMhceNexYjB8RZtXCKfdk2uE)

Then, in the docker-compose.yml, replace the proxy image "quay.io/keycloak/keycloak-gatekeeper:8.0.1" with "nuru/key-gate:KEYCLOAK-10864" (which contains the `keycloak-gatekeeper` binary from this PR) and then docker down, docker up, and you will see the error message is gone. 

See discussion on [Keycloak Dev](https://groups.google.com/forum/#!topic/keycloak-dev/GMFu1Q61PMg) but please add comments here.