### PR TITLE
Migrate the codebase from Gatekeeper repository #516

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 *.swp
 .idea/
+.vscode/
 bin/
 vendor/
 release/
@@ -11,6 +12,7 @@ test.sock
 tests/redis.conf
 tests/*.csr
 *.orig
+*.code-workspace
 debug
 
 *.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: go
 
 matrix:
   include:
+  - go: 1.13.x
   - go: 1.12.x
-    env: GO111MODULE=on
-  - go: 1.11.x
     env: GO111MODULE=on
     
 install:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,28 @@
-# Keycloak Community
+# Louketo Community
 
-Keycloak Gatekeeper is an Open Source adapter solution to protect non-Java modern Applications and Services.
+Louketo Proxy is an Open Source adapter solution to protect non-Java modern Applications and Services.
 
 ## Building and working with the codebase
 
 Details for building from source and working with the codebase are provided in the [building and working with the code base](docs/building.md) guide.
 
-## Contributing to Gatekeeper
+## Contributing to Louketo
 
-Gatekeeper is an Open Source community-driven project and we welcome contributions as well as feedback from the community.
+Louketo is an Open Source community-driven project and we welcome contributions as well as feedback from the community.
 
 We do have a few guidelines in place to help you be successful with your contribution.
 
 Here's a quick checklist for a good PR, more details below:
 
-1. [Keycloak Dev Mailing List](https://groups.google.com/forum/#!forum/keycloak-dev)
-2. A JIRA associated with the PR
+1. [Louketo Mailing List](https://groups.google.com/forum/#!forum/louketo)
+2. The issue number associated with the PR
 3. One feature/change per PR
 4. One commit per PR
 5. PR rebased on master (`git rebase`, not `git pull`) 
-5. Commit message is prefixed by JIRA number
-6. No changes to code not directly related to your PR
-7. Includes test
-8. Includes documentation
+6. Commit message including the GitHub issue number
+7. No changes to code not directly related to your PR
+8. Includes test
+9. Includes documentation
 
 Once you have submitted your PR please monitor it for comments/feedback. We reserve the right to close inactive PRs if
 you do not respond within 2 weeks (bear in mind you can always open a new PR if it is closed due to inactivity).
@@ -32,21 +32,21 @@ not be able to respond to your PR immediately. The best place to ping us is on t
 
 ### Finding something to work on
 
-If you would like to contribute to Keycloak, but are not sure exactly what to work on, you can find a number of open
+If you would like to contribute to Louketo, but are not sure exactly what to work on, you can find a number of open
 issues that are awaiting contributions in the 
-[Keycloak JIRA](https://issues.jboss.org/projects/KEYCLOAK/versions/12340167).
+[GitHub Issues](https://github.com/louketo/louketo-proxy/issues).
 
-### Open a discussion on Keycloak Dev Mailing List
+### Open a discussion on Louketo Mailing List
 
-As Keycloak is a community-driven project we require contributors to send a description of what they are planning to 
-work on to the [Keycloak Dev Mailing List](https://groups.google.com/forum/#!forum/keycloak-dev).
+As Louketo is a community-driven project we require contributors to send a description of what they are planning to 
+work on to the [Louketo Mailing List](https://groups.google.com/forum/#!forum/Louketo-dev).
 
 We recommend starting the discussion prior to submitting your PR. Through the mailing list you can get valuable
-feedback both from the core Keycloak team as well as the wider community.
+feedback both from the core Louketo team as well as the wider community.
 
-### Create an issue in Keycloak JIRA
+### Create an issue in GitHub Issues
 
-Take your time to write a proper JIRA including a good summary and description. 
+Take your time to write a proper issue including a good summary and description. 
 
 Remember this may be the first thing a reviewer of your PR will look at to get an idea of what you are proposing 
 and it will also be used by the community in the future to find about what new features and enhancements are included in 
@@ -63,9 +63,9 @@ refactoring.
 
 ### Documentation
 
-We require contributions to include relevant documentation. Alongside your PR for code changes, prepare a PR to the [Keycloak Documentation](https://github.com/keycloak/keycloak-documentation).
+We require contributions to include relevant documentation. Alongside your PR for code changes, prepare a PR to the [Louketo Documentation](https://github.com/Louketo/Louketo-documentation).
 
-In the description of your PR include a link to the PR to [Keycloak Documentation](https://github.com/keycloak/keycloak-documentation).
+In the description of your PR include a link to the PR to [Louketo Documentation](https://github.com/Louketo/Louketo-documentation).
 
 ### Submitting your PR
 
@@ -82,5 +82,5 @@ for more details.
 The above helps us review your PR and also makes it easier for us to maintain the repository. It is also required by
 our automatic merging process. 
 
-We also require that the commit message is prefixed with the Keycloak JIRA issue number (example commit message 
-"KEYCLOAK-9876 My super cool new feature").
+We also require that the commit message is prefixed with the GitHub issue number (example commit message 
+"My super cool new feature #9876").

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-NAME=keycloak-gatekeeper
-AUTHOR=keycloak
+NAME=louketo-proxy
+AUTHOR=louketo
 REGISTRY=docker.io
 GOVERSION ?= 1.10.2
 ROOT_DIR=${PWD}
@@ -43,9 +43,9 @@ docker-build:
 docker-test:
 	@echo "--> Running the docker test"
 	docker run --rm -ti -p 3000:3000 \
-    -v ${ROOT_DIR}/config.yml:/etc/keycloak/config.yml:ro \
+    -v ${ROOT_DIR}/config.yml:/etc/louketo/config.yml:ro \
     -v ${ROOT_DIR}/tests:/opt/tests:ro \
-    ${REGISTRY}/${AUTHOR}/${NAME}:${VERSION} --config /etc/keycloak/config.yml
+    ${REGISTRY}/${AUTHOR}/${NAME}:${VERSION} --config /etc/louketo/config.yml
 
 docker-release:
 	@echo "--> Building a release image"

--- a/README.md
+++ b/README.md
@@ -1,44 +1,32 @@
-# Keycloak
+# Louketo Proxy
 
-Keycloak is an Open Source Identity and Access Management solution for modern Applications and Services.
-
-This repository contains the source code for the Keycloak Gatekeeper. The Gatekeeper is most happy in the company of Keycloak, but is also able to make friends with other OpenID Connect providers. The service supports both access tokens in browser cookie or bearer tokens.
+This repository contains the source code for the Louketo Proxy.
 
 ## Help and Documentation
 
-* [Gatekeeper documentation](https://www.keycloak.org/docs/latest/securing_apps/index.html#_keycloak_generic_adapter)
-* [Keycloak documentation](https://www.keycloak.org/documentation.html)
-* [User Mailing List](https://groups.google.com/d/forum/keycloak-user) - Mailing list for help and general questions about Keycloak
-* [JIRA](https://issues.jboss.org/projects/KEYCLOAK) - Issue tracker for bugs and feature requests
+* [Louketo Proxy documentation](https://louketo.github.io/)
+* [Mailing List](https://groups.google.com/forum/#!forum/louketo) - Mailing list for help and general questions about Keycloak
+* [Issue Tracker](https://github.com/louketo/louketo-proxy/issues) - Issue tracker for bugs and feature requests
 
 
 ## Reporting Security Vulnerabilities
 
-If you've found a security vulnerability, please look at the [instructions on how to properly report it](http://www.keycloak.org/security.html)
+If you've found a security vulnerability, please report send an e-mail to <louketo-security@googlegroups.com>
 
 
 ## Reporting an issue
 
-If you believe you have discovered a defect in Gatekeeper please open an issue in our [Issue Tracker](https://issues.jboss.org/projects/KEYCLOAK).
+If you believe you have discovered a defect in Louketo Proxy please open an issue in our [Issue Tracker](https://github.com/louketo/louketo-proxy/issues).
 Please remember to provide a good summary, description as well as steps to reproduce the issue.
 
 
 ## Getting started
 
-To run Gatekeeper download the distribution from our [website](https://www.keycloak.org/downloads.html). Extract it and run:
+To run Louketo Proxy, please refer to our [building and working with the code base](docs/building.md) guide. Alternatively, you can use the Docker image by running:
 
-    ./keycloak-gatekeeper[.exe] 
-
-Alternatively, you can use the Docker image by running:
-
-    docker run -it --rm quay.io/keycloak/keycloak-gatekeeper
+    docker run -it --rm quay.io/louketo/louketo-proxy
     
-For more details refer to the [Documentation](https://www.keycloak.org/docs/latest/securing_apps/index.html#_keycloak_generic_adapter).
-
-
-## Building from Source
-
-To build from source refer to the [building and working with the code base](docs/building.md) guide.
+For more details refer to the [Documentation](https://louketo.github.io/).
 
 ### Writing Tests
 
@@ -46,18 +34,13 @@ To write tests refer to the [writing tests](docs/tests-development.md) guide.
 
 ## Contributing
 
-Before contributing to Gatekeeper please read our [contributing guidelines](CONTRIBUTING.md).
-
+Before contributing to Louketo Proxy please read our [contributing guidelines](CONTRIBUTING.md).
 
 ## Other Keycloak Projects
 
 * [Keycloak](https://github.com/keycloak/keycloak) - Keycloak Server and Java adapters
 * [Keycloak Documentation](https://github.com/keycloak/keycloak-documentation) - Documentation for Keycloak
 * [Keycloak QuickStarts](https://github.com/keycloak/keycloak-quickstarts) - QuickStarts for getting started with Keycloak
-* [Keycloak Docker](https://github.com/jboss-dockerfiles/keycloak) - Docker images for Keycloak
-* [Keycloak Node.js Connect](https://github.com/keycloak/keycloak-nodejs-connect) - Node.js adapter for Keycloak
-* [Keycloak Node.js Admin Client](https://github.com/keycloak/keycloak-nodejs-admin-client) - Node.js library for Keycloak Admin REST API
-
 
 ## License
 

--- a/cli.go
+++ b/cli.go
@@ -38,7 +38,7 @@ func newOauthProxyApp() *cli.App {
 	app.Author = author
 	app.Email = email
 	app.Flags = getCommandLineOptions()
-	app.UsageText = "keycloak-gatekeeper [options]"
+	app.UsageText = "louketo-proxy [options]"
 
 	// step: the standard usage message isn't that helpful
 	app.OnUsageError = func(context *cli.Context, err error, isSubcommand bool) error {

--- a/doc.go
+++ b/doc.go
@@ -36,9 +36,9 @@ var (
 type contextKey int8
 
 const (
-	prog        = "keycloak-gatekeeper"
-	author      = "Keycloak"
-	email       = "keycloak-user@lists.jboss.org"
+	prog        = "louketo-proxy"
+	author      = "Louketo"
+	email       = "louketo@googlegroups.com"
 	description = "is a proxy using the keycloak service for auth and authorization"
 
 	authorizationHeader = "Authorization"
@@ -212,7 +212,7 @@ type Config struct {
 	EnableDefaultDeny bool `json:"enable-default-deny" yaml:"enable-default-deny" usage:"enables a default denial on all requests, you have to explicitly say what is permitted (recommended)"`
 	// EnableEncryptedToken indicates the access token should be encoded
 	EnableEncryptedToken bool `json:"enable-encrypted-token" yaml:"enable-encrypted-token" usage:"enable encryption for the access tokens"`
-	// ForceEncryptedCookie indicates that the access token in the cookie should be encoded, regardless what EnableEncryptedToken says. This way, gatekeeper may receive tokens in header in the clear, whereas tokens in cookies remain encrypted
+	// ForceEncryptedCookie indicates that the access token in the cookie should be encoded, regardless what EnableEncryptedToken says. This way, Louketo Proxy may receive tokens in header in the clear, whereas tokens in cookies remain encrypted
 	ForceEncryptedCookie bool `json:"force-encrypted-cookie" yaml:"force-encrypted-cookie" usage:"force encryption for the access tokens in cookies"`
 	// EnableLogging indicates if we should log all the requests
 	EnableLogging bool `json:"enable-logging" yaml:"enable-logging" usage:"enable http logging of the requests"`

--- a/docs/building.md
+++ b/docs/building.md
@@ -5,16 +5,16 @@ Ensure you have Golang 1.11 (or newer) and Git installed
     go version
     git --version
     
-First clone the Gatekeeper repository:
+First clone the Louketo Proxy repository:
     
-    git clone https://github.com/keycloak/keycloak-gatekeeper.git
-    cd keycloak-gatekeeper
+    git clone https://github.com/louketo/louketo-proxy.git
+    cd louketo
     
-To build Gatekeeper run:
+To build Louketo Proxy run:
 
     make && make test
     
-This will compile Go files and package the results into a binary file inside `bin/keycloak-gatekeeper` and run the testsuite. 
+This will compile Go files and package the results into a binary file inside `bin/louketo-proxy` and run the testsuite. 
 
 To build a distribution run:
 
@@ -22,17 +22,16 @@ To build a distribution run:
     
 Once completed you will find distribution archives in the `release` folder.
 
-## Starting Gatekeeper
+## Starting Louketo
 
-To start Gatekeeper during development first build as specified above, then run:
+To start Louketo Proxy during development first build as specified above, then run:
 
-    bin/keycloak-gatekeeper
+    bin/louketo-proxy
 
 ## Working with the codebase
 
-We don't currently enforce a code style in Gatekeeper, because Go already have tools to ensure that code is properly formatted. Before submitting any pull request, please run:
+We don't currently enforce a code style in Louketo, because Go already have tools to ensure that code is properly formatted. Before submitting any pull request, please run:
 
     make format && make lint
 
-If your changes require introducing new dependencies or updating dependency versions please discuss this first on the
-dev mailing list. We do not accept new dependencies to be added lightly, so try to use what is available.
+If your changes require introducing new dependencies or updating dependency versions please discuss this first on the mailing list. We do not accept new dependencies to be added lightly, so try to use what is available.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,3 +1,0 @@
-<!---
-Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
--->

--- a/docs/tests-development.md
+++ b/docs/tests-development.md
@@ -1,12 +1,9 @@
 ## Writing tests
 
-When writing tests please follow the same approach as we have taken in the other tests. There are many ways to 
-test software and we have chosen ours, so please appreciate that.
+When writing tests please follow the same approach as we have taken in the other tests. There are many ways to test software and we have chosen ours, so please appreciate that.
 
 The main tests are provided in files with the suffix `_test.go` and can be executed by running:
 
     make test
 
-When developing your test depending on the feature or enhancement you are testing you may find it best to add to an
-existing test, or to write a test from scratch. For the latter, we recommend finding another test that is close to what 
-you need and use that as a basis.
+When developing your test depending on the feature or enhancement you are testing you may find it best to add to an existing test, or to write a test from scratch. For the latter, we recommend finding another test that is close to what you need and use that as a basis.

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -57,7 +57,7 @@ func checkListenOrBail(endpoint string) bool {
 	return limit < maxWaitCycles
 }
 
-func runTestGatekeeper(t *testing.T, config *Config) error {
+func runTestLouketo(t *testing.T, config *Config) error {
 	proxy, err := newProxy(config)
 	if err != nil {
 		return err
@@ -140,8 +140,8 @@ func TestCorsWithUpstream(t *testing.T) {
 	// launch fake oauth OIDC server
 	_ = runTestAuth(t)
 
-	// launch keycloak-gatekeeper proxy
-	_ = runTestGatekeeper(t, config)
+	// launch louketo-proxy proxy
+	_ = runTestLouketo(t, config)
 
 	// ok now exercise the ensemble with a CORS-enabled request
 	client := http.Client{}

--- a/forwarding.go
+++ b/forwarding.go
@@ -45,7 +45,7 @@ func (r *oauthProxy) proxyMiddleware(next http.Handler) http.Handler {
 		req.Header.Set("X-Forwarded-Proto", req.Header.Get("X-Forwarded-Proto"))
 
 		if len(r.config.CorsOrigins) > 0 {
-			// if CORS is enabled by gatekeeper, do not propagate CORS requests upstream
+			// if CORS is enabled by Louketo Proxy, do not propagate CORS requests upstream
 			req.Header.Del("Origin")
 		}
 		// @step: add any custom headers to the request

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/keycloak/keycloak-gatekeeper
+module github.com/louketo/louketo-proxy
 
 require (
 	github.com/PuerkitoBio/purell v1.1.0

--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-NAME="keycloak-gatekeeper"
+NAME="louketo-proxy"
 PLATFORMS="darwin linux windows"
 ARCHITECTURES="amd64"
 GIT_SHA=$(git --no-pager describe --always --dirty)
@@ -7,7 +7,8 @@ BUILD_TIME=$(date '+%s')
 LFLAGS="-X main.gitsha=$GIT_SHA -X main.compiled=$BUILD_TIME"
 
 DIR="$PWD"
-VERSION=`./get-version.sh`
+# Release an Alpha so we can provide all the binaries for people to give it a try
+VERSION="1.0.0-alpha"
 echo "Version: $VERSION"
 
 TMP=`mktemp -d`
@@ -45,11 +46,12 @@ echo ""
 clean
 release
 
-echo "------------------------------------------------------------------------------------------------------------"
-echo "Upload to jboss.org:"
-echo ""
+# TODO Use goreleases instead
+#echo "------------------------------------------------------------------------------------------------------------"
+#echo "Upload to jboss.org:"
+#echo ""
 
-rsync -rv --protocol=28 $DIR/release/* keycloak@filemgmt.jboss.org:/downloads_htdocs/keycloak/$VERSION/gatekeeper/
+#rsync -rv --protocol=28 $DIR/release/* keycloak@filemgmt.jboss.org:/downloads_htdocs/keycloak/$VERSION/louketo/
 
 echo "------------------------------------------------------------------------------------------------------------"
 echo "Done"

--- a/server.go
+++ b/server.go
@@ -383,7 +383,7 @@ func (r *oauthProxy) Run() error {
 	r.listener = listener
 
 	go func() {
-		r.log.Info("keycloak proxy service starting", zap.String("interface", r.config.Listen))
+		r.log.Info("Louketo proxy service starting", zap.String("interface", r.config.Listen))
 		if err = server.Serve(listener); err != nil {
 			if err != http.ErrServerClosed {
 				r.log.Fatal("failed to start the http service", zap.Error(err))
@@ -393,7 +393,7 @@ func (r *oauthProxy) Run() error {
 
 	// step: are we running http service as well?
 	if r.config.ListenHTTP != "" {
-		r.log.Info("keycloak proxy http service starting", zap.String("interface", r.config.ListenHTTP))
+		r.log.Info("Louketo proxy http service starting", zap.String("interface", r.config.ListenHTTP))
 		httpListener, err := r.createHTTPListener(listenerConfig{
 			listen:        r.config.ListenHTTP,
 			proxyProtocol: r.config.EnableProxyProtocol,
@@ -610,7 +610,7 @@ func (r *oauthProxy) createUpstreamProxy(upstream *url.URL) error {
 
 	// headers formed by middleware before proxying to upstream shall be
 	// kept in response. This is true for CORS headers ([KEYCOAK-9045])
-	// and for refreshed cookies (htts://github.com/keycloak/keycloak-gatekeeper/pulls/456])
+	// and for refreshed cookies (htts://github.com/louketo/louketo-proxy/pulls/456])
 	proxy.KeepDestinationHeaders = true
 	proxy.Logger = httplog.New(ioutil.Discard, "", 0)
 	proxy.KeepDestinationHeaders = true

--- a/store_boltdb.go
+++ b/store_boltdb.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	dbName = "keycloak"
+	dbName = "louketo"
 )
 
 var (

--- a/store_boltdb_test.go
+++ b/store_boltdb_test.go
@@ -39,7 +39,7 @@ func (f *fakeBoltDBStore) close() {
 }
 
 func newTestBoldDB(t *testing.T) *fakeBoltDBStore {
-	tmpfile, err := ioutil.TempFile("/tmp", "keycloak-gatekeeper")
+	tmpfile, err := ioutil.TempFile("/tmp", "louketo-proxy")
 	if err != nil {
 		t.Fatalf("unable to create temporary file, error: %s", err)
 	}

--- a/tests/ca-csr.json
+++ b/tests/ca-csr.json
@@ -1,5 +1,5 @@
 {
-  "CN": "Keycloak Proxy",
+  "CN": "Louketo Proxy",
   "CA": {
     "expiry": "87600h"
   },
@@ -11,7 +11,7 @@
     {
       "C": "GB",
       "L": "London",
-      "O": "Keycloak Proxy",
+      "O": "Louketo Proxy",
       "OU": "Dev Environment",
       "ST": "London"
     }

--- a/utils.go
+++ b/utils.go
@@ -87,7 +87,7 @@ func createCertificate(key *rsa.PrivateKey, hostnames []string, expire time.Dura
 		SignatureAlgorithm:    x509.SHA512WithRSA,
 		Subject: pkix.Name{
 			CommonName:   hostnames[0],
-			Organization: []string{"Keycloak Proxy"},
+			Organization: []string{"Louketo Proxy"},
 		},
 	}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -147,12 +147,12 @@ func TestEncryptDataBlock(t *testing.T) {
 		Ok   bool
 	}{
 		{
-			Text: "hello world, my name is keycloak proxy",
+			Text: "hello world, my name is Louketo proxy",
 			Key:  "DtNMS2eO7Fi5vsuLrW55nrRbir2kPfTw",
 			Ok:   true,
 		},
 		{
-			Text: "hello world, my name is keycloak proxy",
+			Text: "hello world, my name is Louketo proxy",
 			Key:  "DtNMS2eO7Fi5vsu",
 		},
 		{
@@ -250,7 +250,7 @@ func TestDecryptDataBlock(t *testing.T) {
 		Ok   bool
 	}{
 		{
-			Text: "hello world, my name is keycloak proxy",
+			Text: "hello world, my name is Louketo proxy",
 			Key:  "DtNMS2eO7Fi5vsuLrW55nrRbir2kPfss",
 			Ok:   true,
 		},


### PR DESCRIPTION
In the past month, [we discussed](https://groups.google.com/forum/#!msg/keycloak-dev/oDyw94BWxM0/zc0J9R10BwAJ) the idea of having a new home for Gatekeeper, based on that we decided to create a new
organization on GitHub and rename the project to [Louketo Proxy](https://www.wordhippo.com/what-is/the-meaning-of/greek-word-b1b9dc52a1b1d327a31a9684bd7c34f9af80baf1.html).

This pull request refactors the codebase to the new name and should be merged only after the transfer
of the repository.

## Some considerations

* The documentation will be improved, but it's out of the scope for this pull-request
* Migration of the [Dockerfile](https://github.com/keycloak/keycloak-containers/tree/master/gatekeeper) after the transition, that also covers #541.
* There's a lot of work to do this week, so please be patient :)