### PR TITLE
Use end-session-endpoint in logout redirects if it exists

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -348,6 +348,10 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 	// @check if we should redirect to the provider
 	if r.config.EnableLogoutRedirect {
 		sendTo := fmt.Sprintf("%s/protocol/openid-connect/logout", strings.TrimSuffix(r.config.DiscoveryURL, "/.well-known/openid-configuration"))
+		if r.idp.EndSessionEndpoint != nil {
+			sendTo = r.idp.EndSessionEndpoint.String()
+		}
+
 
 		// @step: if no redirect uri is set
 		if redirectURL == "" {


### PR DESCRIPTION
## Summary 
When logging out, the change will cause a redirect to the `end_session_endpoint` from the discovery doc if that endpoint is specified, and if the `enable-logout-redirect` option is selected.

## Type

[x] Bug fix
[] Feature request
[] Enhancement
[] Docs

## Why?

If the issuer does not have an end session endpoint matching `$ISSUER/protocol/openid-connect/logout`, then a user will most likely be redirected to an invalid page

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.

