### PR TITLE
Added fallback if no realm roles were detected; It now extracts the r…

### DIFF
--- a/user_context.go
+++ b/user_context.go
@@ -63,6 +63,15 @@ func extractIdentity(token jose.JWT) (*userContext, error) {
 		}
 	}
 
+	// @step: fallback to pure roles extraction if no realm roles were detected
+	if len(roleList) == 0 {
+		if roles, found := claims[claimResourceRoles]; found {
+			for _, r := range roles.([]interface{}) {
+				roleList = append(roleList, fmt.Sprintf("%s", r))
+			}
+		}
+	}
+
 	// @step: extract the client roles from the access token
 	if accesses, found := claims[claimResourceAccess].(map[string]interface{}); found {
 		for name, list := range accesses {


### PR DESCRIPTION
First of all, some explanation is required for this PR I think. I'm trying to get the proxy working with Azure App Registrations (or Enterprise Applications, whatever you want to call them).

Azure supports something they call AppRoles. How you manage them is not very relevant, but suffice to say, it results in a "roles" claim in the ID token. To support this usecase in louketo, I've added a fallback to the user_context that tries to extract the roles claims *after* it fails to load the realm roles. This is the easiest fixt.

If you find this acceptable, that would of course be nice, but maybe it's better to have a commandline option to control this behaviour. I don't think it's bad behaviour, and it won't break anything since the roles claim cannot be forged and is within trusted context. If no realm roles were found, it means Keycloak is not in the picture, and we are just using plain OIDC.

# Title
Roles claim fallback

## Summary 
This adds an extra parse step of the claims in the ID token to 'find' roles.

## Type

[] Bug fix
[] Feature request
[x] Enhancement
[] Docs

## Why?
It 'fixes' roles functionality coming from Azure AD AppRoles.

## Requirements
A working App Registration / Enterprise Application with AppRoles setup.
## How to try it?
Guide: https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps
## Documentation
I don't think it's required just yet. But if so, I can write some.

## Additional Information

It's my first PR for this repo, please be gentle :)

## Checklist:
- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.