### PR TITLE
Update to user-guide.md - fix sign-in-page switch

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -452,7 +452,7 @@ By default, Louketo Proxy will immediately redirect you
 for authentication and hand back a 403 for access denied. Most users
 will probably want to present the user with a more friendly sign-in and
 access denied page. You can pass the command line options (or via config
-file) paths to the files with `--signin-page=PATH`. The sign-in page
+file) paths to the files with `--sign-in-page=PATH`. The sign-in page
 will have a 'redirect' variable passed into the scope and holding the
 OAuth redirection URL. If you wish to pass additional variables into the
 templates, such as title, sitename and so on, you can use the -`-tags


### PR DESCRIPTION
Incorrect Documentation - should be "sign-in-page" not "sign-page".
# Update to user-guide.md - fix sign-in-page switch

## Summary 

The documentation incorrectly states the switch to use a custom sign in pages as signin-page. This should be sign-in-page. 

## Type

[] Bug fix
[] Feature request
[] Enhancement
[X] Docs

## Why?

Incorrect documentation should be fixed. 

## Requirements


## How to try it?

```yaml
discovery-url: https://keycloak.example.com/auth/realms/<REALM_NAME>
client-id: <CLIENT_ID>
client-secret: <CLIENT_SECRET>
listen: :3000
enable-refresh-tokens: true
tls-cert:
tls-private-key:
redirection-url: http://127.0.0.1:3000
encryption-key: <ENCRYPTION_KEY>
upstream-url: http://127.0.0.1:80
forbidden-page: /html/forbidden.html
sign-in-page: /html/signin.html
resources:
  - uri: /
```

## Documentation


## Additional Information


## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ x ] I have updated the documentation/CHANGELOG accordingly.

