### PR TITLE
Added opentracing jaeger middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Signal Louketo Fork
+
+Signal AI specific additions to Louketo Proxy
+
+## Releasing
+
+To release changes follow the instructions in [the releasing documentation](docs/release.md). This uses GitHub Actions.
+
 # EOL notice
 
 Louketo Proxy reached end of line in November 21, 2020. This means that we no longer support, or update it. The details are available [here](https://www.keycloak.org/2020/08/sunsetting-louketo-project.adoc).

--- a/config.go
+++ b/config.go
@@ -43,6 +43,7 @@ func newDefaultConfig() *Config {
 		EnableDefaultDeny:             true,
 		EnableSessionCookies:          true,
 		EnableTokenHeader:             true,
+		EnableCSRFCheck:               false,
 		HTTPOnlyCookie:                true,
 		Headers:                       make(map[string]string),
 		LetsEncryptCacheDir:           "./cache/",

--- a/config.go
+++ b/config.go
@@ -43,7 +43,7 @@ func newDefaultConfig() *Config {
 		EnableDefaultDeny:             true,
 		EnableSessionCookies:          true,
 		EnableTokenHeader:             true,
-		EnableCSRFCheck:               false,
+		EnableCSRFCheck:               true,
 		HTTPOnlyCookie:                true,
 		Headers:                       make(map[string]string),
 		LetsEncryptCacheDir:           "./cache/",

--- a/doc.go
+++ b/doc.go
@@ -252,6 +252,8 @@ type Config struct {
 	LocalhostMetrics bool `json:"localhost-metrics" yaml:"localhost-metrics" usage:"enforces the metrics page can only been requested from 127.0.0.1"`
 	// EnableCompression enables gzip compression for response
 	EnableCompression bool `json:"enable-compression" yaml:"enable-compression" usage:"enable gzip compression for response"`
+	// EnableCSRFCheck enables CSRF protection between authorise/callback using cookies and state parameter
+	EnableCSRFCheck bool `json:"enable-csrf-check" yaml:"enable-csrf-check" usage:"enable crsf check between authorise and callback"`
 
 	// AccessTokenDuration is default duration applied to the access token cookie
 	AccessTokenDuration time.Duration `json:"access-token-duration" yaml:"access-token-duration" usage:"fallback cookie duration for the access token when using refresh tokens"`

--- a/forwarding.go
+++ b/forwarding.go
@@ -88,8 +88,9 @@ func (r *oauthProxy) proxyMiddleware(next http.Handler) http.Handler {
 // forwardProxyHandler is responsible for signing outbound requests
 func (r *oauthProxy) forwardProxyHandler() func(*http.Request, *http.Response) {
 	ctx := context.Background()
+	fmt.Printf("%+v\n", r.config.RedirectionURL)
 	conf := r.newOAuth2Config(r.config.RedirectionURL)
-
+	fmt.Printf("%+v\n", conf)
 	// the loop state
 	var state struct {
 		// the access token

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.0
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/armon/go-proxyproto v0.0.0-20180202201750-5b7edb60ff5f
+	github.com/client9/misspell v0.3.4 // indirect
 	github.com/codegangsta/negroni v1.0.0 // indirect
 	github.com/coreos/go-oidc v0.0.0-20171020180921-e860bd55bfa7
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/louketo/louketo-proxy
 
 require (
+	github.com/MicahParks/keyfunc v1.9.0
 	github.com/PuerkitoBio/purell v1.1.0
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/armon/go-proxyproto v0.0.0-20180202201750-5b7edb60ff5f
-	github.com/client9/misspell v0.3.4 // indirect
 	github.com/codegangsta/negroni v1.0.0 // indirect
 	github.com/coreos/go-oidc v0.0.0-20171020180921-e860bd55bfa7
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
@@ -15,6 +15,7 @@ require (
 	github.com/garyburd/redigo v1.6.0 // indirect
 	github.com/go-chi/chi v3.3.3+incompatible
 	github.com/gofrs/uuid v3.3.0+incompatible
+	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/armon/go-proxyproto v0.0.0-20180202201750-5b7edb60ff5f h1:SaJ6yqg936T
 github.com/armon/go-proxyproto v0.0.0-20180202201750-5b7edb60ff5f/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
+github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codegangsta/negroni v1.0.0 h1:+aYywywx4bnKXWvoWtRfJ91vC59NbEhEY03sZjQhbVY=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
 github.com/coreos/go-oidc v0.0.0-20171020180921-e860bd55bfa7 h1:UeXD8Kli+SWhDlj1ikNXs9NKHsm2SR9dVnGiKq86DJ4=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
+github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
 github.com/PuerkitoBio/purell v1.1.0 h1:rmGxhojJlM0tuKtfdvliR84CFHljx9ag64t2xmVkjK4=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
@@ -7,8 +9,6 @@ github.com/armon/go-proxyproto v0.0.0-20180202201750-5b7edb60ff5f h1:SaJ6yqg936T
 github.com/armon/go-proxyproto v0.0.0-20180202201750-5b7edb60ff5f/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
-github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
-github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codegangsta/negroni v1.0.0 h1:+aYywywx4bnKXWvoWtRfJ91vC59NbEhEY03sZjQhbVY=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
 github.com/coreos/go-oidc v0.0.0-20171020180921-e860bd55bfa7 h1:UeXD8Kli+SWhDlj1ikNXs9NKHsm2SR9dVnGiKq86DJ4=
@@ -30,6 +30,9 @@ github.com/go-chi/chi v3.3.3+incompatible h1:KHkmBEMNkwKuK4FdQL7N2wOeB9jnIx7jR5w
 github.com/go-chi/chi v3.3.3+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
+github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -80,7 +83,6 @@ golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20181201002055-351d144fa1fc h1:a3CU5tJYVj92DY2LaA1kUkrsqD5/3mLDhx2NcNqyW+0=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
@@ -88,7 +90,6 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/handlers.go
+++ b/handlers.go
@@ -313,9 +313,9 @@ func (r *oauthProxy) loginHandler(w http.ResponseWriter, req *http.Request) {
 func emptyHandler(w http.ResponseWriter, req *http.Request) {}
 
 // logoutHandler performs a logout
-//  - if it's just a access token, the cookie is deleted
-//  - if the user has a refresh token, the token is invalidated by the provider
-//  - optionally, the user can be redirected by to a url
+//   - if it's just a access token, the cookie is deleted
+//   - if the user has a refresh token, the token is invalidated by the provider
+//   - optionally, the user can be redirected by to a url
 func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 	// @check if the redirection is there
 	var redirectURL string
@@ -330,7 +330,7 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// @step: drop the access token
-	user, err := r.getIdentity(req)
+	user, err := r.getIdentityFromRequest(req)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -434,7 +434,7 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 
 // expirationHandler checks if the token has expired
 func (r *oauthProxy) expirationHandler(w http.ResponseWriter, req *http.Request) {
-	user, err := r.getIdentity(req)
+	user, err := r.getIdentityFromRequest(req)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		return
@@ -449,7 +449,7 @@ func (r *oauthProxy) expirationHandler(w http.ResponseWriter, req *http.Request)
 
 // tokenHandler display access token to screen
 func (r *oauthProxy) tokenHandler(w http.ResponseWriter, req *http.Request) {
-	user, err := r.getIdentity(req)
+	user, err := r.getIdentityFromRequest(req)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/middleware.go
+++ b/middleware.go
@@ -321,6 +321,7 @@ func (r *oauthProxy) authenticationMiddleware() func(http.Handler) http.Handler 
 						next.ServeHTTP(w, req.WithContext(r.redirectToAuthorization(w, req)))
 						return
 					}
+					scope.Identity = user
 					ctx = context.WithValue(req.Context(), contextScopeName, scope)
 				}
 			}

--- a/misc_test.go
+++ b/misc_test.go
@@ -33,9 +33,10 @@ func TestRedirectToAuthorizationUnauthorized(t *testing.T) {
 func TestRedirectToAuthorization(t *testing.T) {
 	requests := []fakeRequest{
 		{
-			URI:              "/admin",
+			URI:              "/admin?blah=1",
 			Redirects:        true,
 			ExpectedLocation: "/oauth/authorize?state",
+			ExpectedStateUrl: "/admin?blah=1",
 			ExpectedCode:     http.StatusSeeOther,
 		},
 	}

--- a/oauth.go
+++ b/oauth.go
@@ -32,7 +32,7 @@ import (
 	"github.com/coreos/go-oidc/oidc"
 )
 
-//FIXME remove constants in the future which hopefully won't be necessary in the next releases
+// FIXME remove constants in the future which hopefully won't be necessary in the next releases
 const (
 	GrantTypeAuthCode     = "authorization_code"
 	GrantTypeUserCreds    = "password"

--- a/oauth.go
+++ b/oauth.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/coreos/go-oidc/jose"
+	"github.com/golang-jwt/jwt/v4"
 
 	"github.com/coreos/go-oidc/oidc"
 )
@@ -61,6 +62,15 @@ func verifyToken(client *oidc.Client, token jose.JWT) error {
 		if strings.Contains(err.Error(), "token is expired") {
 			return ErrAccessTokenExpired
 		}
+		return err
+	}
+
+	return nil
+}
+
+// verifyToken verify that the token in the user context is valid
+func verifyTokenSignature(keyfunc jwt.Keyfunc, token string) error {
+	if _, err := jwt.Parse(token, keyfunc, jwt.WithoutClaimsValidation()); err != nil {
 		return err
 	}
 

--- a/session_test.go
+++ b/session_test.go
@@ -62,7 +62,7 @@ func TestGetIndentity(t *testing.T) {
 	}
 
 	for i, c := range testCases {
-		user, err := p.getIdentity(c.Request)
+		user, err := p.getIdentityFromRequest(c.Request)
 		if err != nil && c.Ok {
 			t.Errorf("test case %d should not have errored", i)
 			continue

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/net/websocket"
 )
 
-//TestWebSocket is used to validate that the proxy reverse proxy WebSocket connections.
+// TestWebSocket is used to validate that the proxy reverse proxy WebSocket connections.
 func TestWebSocket(t *testing.T) {
 	// Setup an upstream service.
 	upstream := &fakeUpstreamService{}


### PR DESCRIPTION
<!-- 
Please use this template when submitting a new feature request with as much details as possible. Not doing so may result in the issue not being addressed in a timely manner or eventually closed.
-->
# Added opentracing jaeger middleware

## Summary 

Discussion here: https://groups.google.com/forum/#!topic/louketo/Dach4U_Iza8

**Proposal**
Introduce a flag to enable opentracing, under this flag:
Write some middleware to add extraction and injection of traces with some basic debug tags
Initialise a jaeger client to report spans


## Type

[] Bug fix
[] Feature request
[x] Enhancement
[] Docs

## Why?

Keycloak itself uses wildfly. Wildfly introduced support for open tracing https://wildfly.org/news/tags/wildfly/page/2/. There is talk of introducing support to Keycloak
It would be good see the auth flow through opentracing for debugging.  
For us, we would like to integrate the gatekeeper into our auth flow for debugging.

## Requirements

Configured using the standard jaeger client env variables

## How to try it?

Use jaeger-all-in-one https://www.jaegertracing.io/docs/1.18/getting-started/ to test locally.

## Documentation

Can write this as needed.

## Additional Information

I can't see a clean way the proxy closes so right now this is not cleanly closing the jaeger client. Is cleanly shutting down also something worth thinking about?

## Checklist:

Happy to help with anything the further this. 

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.

